### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -6,6 +6,9 @@ on:
     branches:
       - master
 
+permissions:
+  contents: read
+
 jobs:
   deploy:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/Fil-Language/website/security/code-scanning/2](https://github.com/Fil-Language/website/security/code-scanning/2)

To fix the issue, we will add a `permissions` block to the root of the workflow file. This block will explicitly define the least privileges required for the workflow to function correctly. Based on the workflow's operations, it does not need write access to the repository contents, so we will set `contents: read`. If additional permissions are required for specific jobs, they can be defined within the respective job blocks.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
